### PR TITLE
Add information to README.md about using NVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ Shiki::highlight(
 );
 ```
 
+## Using Node Version Manager
+
+Under the hood, this package runs a node command  to render the markdown. If you use NVM during development, 
+then the package will be unlikely to find your version of node as it looks for the node executable in
+`/usr/local/bin` and `/opt/homebrew/bin` - if this is the case, then you should create a symlink between
+the node distributable in your NVM folder, to that of the `usr/local/bin`. Such a command might look like this:
+
+```bash
+sudo ln -s /home/some-user/.nvm/versions/node/v17.3.1/bin/node /usr/local/bin/node
+```
+
+Creating this symlink will allow the package to find your NPM executable. Please note, if you change
+your NPM version you will have to update your symlinks accordingly.
+
 ## Testing
 
 You can run all the tests with this command:


### PR DESCRIPTION
Hey Guys!

I tried out the [spatie/markdown](https://github.com/spatie/laravel-markdown) package yesterday and I got stuck on why it would not render properly. It transpires the issue was that I use NVM, and the package was looking for node in a particular place, where it was not. It took me far longer to realize that this was what was happening, and required the help of someone in the Laracasts forum too!

My first though was to update the package to accept another variable, so the user could specify the location of their node executable. But then I decided it probably made more sense just to symlink the file instead, as the likelihood is, in production, node would be installed instead of NVM, so it's less of an issue.

I figured it would be good to add this to the readme, to help anyone else that gets stuck. If this PR is accepted, I will also make a similar on one the spatie/markdown package too!

Thanks Guys :)