### PR TITLE
Downgrade to php7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.0]
+        php: [7.4, 8.1, 8.0]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,40 @@ Shiki::highlight(
 
 You can then target these classes in your own CSS to color these lines how you want.
 
+## PHP 7.4 support
+
+Shiki has a nice and easy syntax in combination with at least PHP 8.
+
+It does support PHP 7.4, but does loose a little bit of it's nice syntax if using it with PHP7.4, as you need to follow the order of the variables.
+
+```php
+// As reference
+highlight(
+    string $code,
+    ?string $language = 'php',
+    ?string $theme = 'nord',
+    ?array $highlightLines = [],
+    ?array $addLines = [],
+    ?array $deleteLines = [],
+    ?array $focusLines = []
+)
+
+// Instead of PHP 8 syntax
+Shiki::highlight(
+    code: $code,
+    language: 'php',
+    deleteLines: [1],
+);
+
+// You need to follow PHP 7.4 syntax
+Shiki::highlight(
+    $code,
+    'php',
+    null,
+    null,
+    [1],
+);
+
 ## Determining available languages
 
 To get an array with [all languages that Shiki supports](https://github.com/shikijs/shiki/blob/master/docs/languages.md), call `getAvailableLanguages`

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^7.4|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.0",
@@ -45,7 +45,10 @@
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "shiki-php",
       "license": "MIT",
       "dependencies": {
         "shiki": "^0.9.5"

--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -29,7 +29,7 @@ class Shiki
         $language = $language ?? 'php';
         $theme = $theme ?? 'nord';
 
-        return (new static)->highlightCode($code, $language, $theme, [
+        return (new static())->highlightCode($code, $language, $theme, [
             'highlightLines' => $highlightLines ?? [],
             'addLines' => $addLines ?? [],
             'deleteLines' => $deleteLines ?? [],

--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -8,6 +8,8 @@ use Symfony\Component\Process\Process;
 
 class Shiki
 {
+    protected string $defaultTheme;
+
     private static ?string $customWorkingDirPath = null;
 
     public static function setCustomWorkingDirPath(?string $path)
@@ -22,9 +24,9 @@ class Shiki
         array $highlightLines = [],
         array $addLines = [],
         array $deleteLines = [],
-        array $focusLines = [],
+        array $focusLines = []
     ): string {
-        return (new static())->highlightCode($code, $language, $theme, [
+        return (new static)->highlightCode($code, $language, $theme, [
             'highlightLines' => $highlightLines,
             'addLines' => $addLines,
             'deleteLines' => $deleteLines,
@@ -48,9 +50,9 @@ class Shiki
         return $languages;
     }
 
-    public function __construct(
-        protected string $defaultTheme = 'nord'
-    ) {
+    public function __construct(string $defaultTheme = 'nord')
+    {
+        $this->defaultTheme = $defaultTheme;
     }
 
     public function getAvailableThemes(): array
@@ -98,9 +100,9 @@ class Shiki
         ];
 
         $process = new Process(
-            command: $command,
-            cwd: $this->getWorkingDirPath(),
-            timeout: null,
+            $command,
+            $this->getWorkingDirPath(),
+            null,
         );
 
         $process->run();

--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -19,18 +19,21 @@ class Shiki
 
     public static function highlight(
         string $code,
-        string $language = 'php',
-        string $theme = 'nord',
-        array $highlightLines = [],
-        array $addLines = [],
-        array $deleteLines = [],
-        array $focusLines = []
+        ?string $language = null,
+        ?string $theme = null,
+        ?array $highlightLines = null,
+        ?array $addLines = null,
+        ?array $deleteLines = null,
+        ?array $focusLines = null
     ): string {
+        $language = $language ?? 'php';
+        $theme = $theme ?? 'nord';
+
         return (new static)->highlightCode($code, $language, $theme, [
-            'highlightLines' => $highlightLines,
-            'addLines' => $addLines,
-            'deleteLines' => $deleteLines,
-            'focusLines' => $focusLines,
+            'highlightLines' => $highlightLines ?? [],
+            'addLines' => $addLines ?? [],
+            'deleteLines' => $deleteLines ?? [],
+            'focusLines' => $focusLines ?? [],
         ]);
     }
 

--- a/tests/ShikiCustomRenderTest.php
+++ b/tests/ShikiCustomRenderTest.php
@@ -24,7 +24,7 @@ it('can highlight php', function () {
 it('can highlight blade', function () {
     $code = '@if(true) {{ "Hello world" }} @endif';
 
-    $highlightedCode = Shiki::highlight($code, language: 'blade');
+    $highlightedCode = Shiki::highlight($code, 'blade');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -36,7 +36,7 @@ it('can highlight complex blade with html inside', function () {
     @endif
     blade;
 
-    $highlightedCode = Shiki::highlight($code, language: 'blade', theme: 'github-light');
+    $highlightedCode = Shiki::highlight($code, 'blade', 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -44,7 +44,7 @@ it('can highlight complex blade with html inside', function () {
 it('can highlight antlers', function () {
     $code = '{{ if }} Hi there {{ /if }}';
 
-    $highlightedCode = Shiki::highlight($code, language: 'antlers');
+    $highlightedCode = Shiki::highlight($code, 'antlers');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -60,7 +60,7 @@ it('can render for a specific language', function () {
 it('can mark lines as highlighted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, highlightLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -72,7 +72,7 @@ it('can mark multiple lines as highlighted', function () {
         return null;
     ";
 
-    $highlightedCode = Shiki::highlight($code, highlightLines: ['1', '2-4']);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', ['1', '2-4']);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -80,7 +80,7 @@ it('can mark multiple lines as highlighted', function () {
 it('can mark lines as added', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, addLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -88,7 +88,7 @@ it('can mark lines as added', function () {
 it('can mark lines as deleted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, deleteLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -96,7 +96,7 @@ it('can mark lines as deleted', function () {
 it('can mark lines as focus', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, focusLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -104,10 +104,7 @@ it('can mark lines as focus', function () {
 it('can receive a custom theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight(
-        $code,
-        theme: __DIR__ . '/testfiles/ayu-light.json'
-    );
+    $highlightedCode = Shiki::highlight($code, 'php', __DIR__ . '/testfiles/ayu-light.json');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -115,7 +112,7 @@ it('can receive a custom theme', function () {
 it('can accept different themes', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, theme: 'github-light');
+    $highlightedCode = Shiki::highlight($code, 'php', 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -123,13 +120,13 @@ it('can accept different themes', function () {
 it('throws on invalid theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    Shiki::highlight($code, theme: 'invalid-theme');
+    Shiki::highlight($code, 'php', 'invalid-theme');
 })->throws(Exception::class);
 
 it('throws on invalid language', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    Shiki::highlight($code, language: 'invalid-language');
+    Shiki::highlight($code, 'invalid-language');
 })->throws(Exception::class);
 
 it('can get all available themes', function () {

--- a/tests/ShikiCustomRenderTest.php
+++ b/tests/ShikiCustomRenderTest.php
@@ -60,7 +60,7 @@ it('can render for a specific language', function () {
 it('can mark lines as highlighted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -72,7 +72,7 @@ it('can mark multiple lines as highlighted', function () {
         return null;
     ";
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', ['1', '2-4']);
+    $highlightedCode = Shiki::highlight($code, null, null, ['1', '2-4']);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -80,7 +80,7 @@ it('can mark multiple lines as highlighted', function () {
 it('can mark lines as added', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -88,7 +88,7 @@ it('can mark lines as added', function () {
 it('can mark lines as deleted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -96,7 +96,7 @@ it('can mark lines as deleted', function () {
 it('can mark lines as focus', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [], [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -104,7 +104,7 @@ it('can mark lines as focus', function () {
 it('can receive a custom theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', __DIR__ . '/testfiles/ayu-light.json');
+    $highlightedCode = Shiki::highlight($code, null, __DIR__ . '/testfiles/ayu-light.json');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -112,7 +112,7 @@ it('can receive a custom theme', function () {
 it('can accept different themes', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'github-light');
+    $highlightedCode = Shiki::highlight($code, null, 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -120,7 +120,7 @@ it('can accept different themes', function () {
 it('throws on invalid theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    Shiki::highlight($code, 'php', 'invalid-theme');
+    Shiki::highlight($code, null, 'invalid-theme');
 })->throws(Exception::class);
 
 it('throws on invalid language', function () {

--- a/tests/ShikiTest.php
+++ b/tests/ShikiTest.php
@@ -21,7 +21,7 @@ it('can highlight php', function () {
 it('can highlight blade', function () {
     $code = '@if(true) {{ "Hello world" }} @endif';
 
-    $highlightedCode = Shiki::highlight($code, language: 'blade');
+    $highlightedCode = Shiki::highlight($code, 'blade');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -33,7 +33,7 @@ it('can highlight complex blade with html inside', function () {
     @endif
     blade;
 
-    $highlightedCode = Shiki::highlight($code, language: 'blade', theme: 'github-light');
+    $highlightedCode = Shiki::highlight($code, 'blade', 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -41,7 +41,7 @@ it('can highlight complex blade with html inside', function () {
 it('can highlight antlers', function () {
     $code = '{{ if }} Hi there {{ /if }}';
 
-    $highlightedCode = Shiki::highlight($code, language: 'antlers');
+    $highlightedCode = Shiki::highlight($code, 'antlers');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -57,7 +57,7 @@ it('can render for a specific language', function () {
 it('can mark lines as highlighted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, highlightLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -69,7 +69,7 @@ it('can mark multiple lines as highlighted', function () {
         return null;
     ";
 
-    $highlightedCode = Shiki::highlight($code, highlightLines: ['1', '2-4']);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', ['1', '2-4']);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -77,7 +77,7 @@ it('can mark multiple lines as highlighted', function () {
 it('can mark lines as added', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, addLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -85,7 +85,7 @@ it('can mark lines as added', function () {
 it('can mark lines as deleted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, deleteLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -93,7 +93,7 @@ it('can mark lines as deleted', function () {
 it('can mark lines as focus', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, focusLines: [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [], [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -101,10 +101,7 @@ it('can mark lines as focus', function () {
 it('can receive a custom theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight(
-        $code,
-        theme: __DIR__ . '/testfiles/ayu-light.json'
-    );
+    $highlightedCode = Shiki::highlight($code, 'php', __DIR__ . '/testfiles/ayu-light.json');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -112,7 +109,7 @@ it('can receive a custom theme', function () {
 it('can accept different themes', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, theme: 'github-light');
+    $highlightedCode = Shiki::highlight($code, 'php', 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -120,13 +117,13 @@ it('can accept different themes', function () {
 it('throws on invalid theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    Shiki::highlight($code, theme: 'invalid-theme');
+    Shiki::highlight($code, 'php', 'invalid-theme');
 })->throws(Exception::class);
 
 it('throws on invalid language', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    Shiki::highlight($code, language: 'invalid-language');
+    Shiki::highlight($code, 'invalid-language');
 })->throws(Exception::class);
 
 it('can get all available themes', function () {

--- a/tests/ShikiTest.php
+++ b/tests/ShikiTest.php
@@ -57,7 +57,7 @@ it('can render for a specific language', function () {
 it('can mark lines as highlighted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -69,7 +69,7 @@ it('can mark multiple lines as highlighted', function () {
         return null;
     ";
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', ['1', '2-4']);
+    $highlightedCode = Shiki::highlight($code, null, null, ['1', '2-4']);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -77,7 +77,7 @@ it('can mark multiple lines as highlighted', function () {
 it('can mark lines as added', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [1]);
+    $highlightedCode = Shiki::highlight($code, null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -85,7 +85,7 @@ it('can mark lines as added', function () {
 it('can mark lines as deleted', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -93,7 +93,7 @@ it('can mark lines as deleted', function () {
 it('can mark lines as focus', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'nord', [], [], [], [1]);
+    $highlightedCode = Shiki::highlight($code, 'php', null, null, null, null, [1]);
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -101,7 +101,7 @@ it('can mark lines as focus', function () {
 it('can receive a custom theme', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', __DIR__ . '/testfiles/ayu-light.json');
+    $highlightedCode = Shiki::highlight($code, null, __DIR__ . '/testfiles/ayu-light.json');
 
     assertMatchesSnapshot($highlightedCode);
 });
@@ -109,7 +109,7 @@ it('can receive a custom theme', function () {
 it('can accept different themes', function () {
     $code = '<?php echo "Hello World"; ?>';
 
-    $highlightedCode = Shiki::highlight($code, 'php', 'github-light');
+    $highlightedCode = Shiki::highlight($code, null, 'github-light');
 
     assertMatchesSnapshot($highlightedCode);
 });


### PR DESCRIPTION
This PR does downgrade so Shiki does support PHP7.4 on top of PHP8 support. 

To make the tests pass, I needed to remove some nice PHP8 syntax. 
```php
// Instead of this
$highlightedCode = Shiki::highlight($code, highlightLines: ['1', '2-4']);

// Downgrade to PHP 7.4
$highlightedCode = Shiki::highlight($code, null, null, ['1', '2-4']);
```

The good thing is, that someone who is using Shiki with PHP 8, can still use the nice PHP 8 syntax. It does only affect those, who wanna use it with PHP7.4.

- Tests do pass for PHP 7.4
- Readme has been updated

## Motivation
It's a little dependency fun :-)

We are working on a PR to add TipTap 2 for Statamic. Statamic does support PHP 7.4 at the moment. 
https://github.com/statamic/cms/pull/6043

To upgrade, Statamic requires [tiptap-php](https://github.com/ueberdosis/tiptap-php/blob/main/composer.json#L19)
In theory, it does support PHP 7.4

As tiptap does require shiki, shiki does require PHP 8 which does prevent it from beeing usable with PHP 7.4