### PR TITLE
feat: support tj/n

### DIFF
--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -93,10 +93,12 @@ class Shiki
 
     protected function callShiki(...$arguments): string
     {
+        $home = getenv("HOME");
         $command = [
             (new ExecutableFinder())->find('node', 'node', [
                 '/usr/local/bin',
                 '/opt/homebrew/bin',
+                $home . '/n/bin', // support https://github.com/tj/n
             ]),
             'shiki.js',
             json_encode(array_values($arguments)),


### PR DESCRIPTION
Adds support for the [n](https://github.com/tj/n) Node version manager, which installs Node.js by default in `$HOME/n`.