### PR TITLE
Re-add `getAvailableLanguages`, `getAvailableThemes`, `languageIsAvailable` and `themeIsAvailable`

### DIFF
--- a/bin/shiki.js
+++ b/bin/shiki.js
@@ -37,6 +37,16 @@ async function main(args) {
 
     if (!customLanguages[language]) await highlighter.loadLanguage(language);
 
+    if (args[0] === 'languages') {
+        process.stdout.write(JSON.stringify(highlighter.getLoadedLanguages()));
+        return;
+    }
+
+    if (args[0] === 'themes') {
+        process.stdout.write(JSON.stringify(highlighter.getLoadedThemes()));
+        return;
+    }
+
     const { theme: theme$ } = highlighter.setTheme(theme)
 
     const result = highlighter.codeToTokens(args[0], {

--- a/bin/shiki.js
+++ b/bin/shiki.js
@@ -58,7 +58,7 @@ async function main(args) {
     }
 
     if (args[0] === 'themes') {
-        process.stdout.write(JSON.stringify(highlighter.getLoadedThemes()));
+        process.stdout.write(JSON.stringify(Object.keys(shiki.bundledThemes)));
         return;
     }
 

--- a/bin/shiki.js
+++ b/bin/shiki.js
@@ -38,7 +38,22 @@ async function main(args) {
     if (!customLanguages[language]) await highlighter.loadLanguage(language);
 
     if (args[0] === 'languages') {
-        process.stdout.write(JSON.stringify(highlighter.getLoadedLanguages()));
+        process.stdout.write(
+            JSON.stringify([
+                ...Object.keys(shiki.bundledLanguagesBase),
+                ...Object.keys(customLanguages),
+            ])
+        );
+        return;
+    }
+
+    if (args[0] === 'aliases') {
+        process.stdout.write(
+            JSON.stringify([
+                ...Object.keys(shiki.bundledLanguages),
+                ...Object.keys(customLanguages),
+            ])
+        );
         return;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "symfony/process": "^7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "symfony/process": "^7.1"
+        "symfony/process": "^5.4|^6.4|^7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.0",

--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -37,9 +37,37 @@ class Shiki
         ]);
     }
 
+    public function getAvailableLanguages(): array
+    {
+        $shikiResult = $this->callShiki('languages');
+
+        $languages = json_decode($shikiResult, true);
+
+        sort($languages);
+
+        return $languages;
+    }
+
     public function __construct(string $defaultTheme = 'nord')
     {
         $this->defaultTheme = $defaultTheme;
+    }
+
+    public function getAvailableThemes(): array
+    {
+        $shikiResult = $this->callShiki('themes');
+
+        return json_decode($shikiResult, true);
+    }
+
+    public function languageIsAvailable(string $language): bool
+    {
+        return in_array($language, $this->getAvailableLanguages());
+    }
+
+    public function themeIsAvailable(string $theme): bool
+    {
+        return in_array($theme, $this->getAvailableThemes());
     }
 
     public function highlightCode(string $code, string $language, ?string $theme = null, ?array $options = []): string

--- a/src/Shiki.php
+++ b/src/Shiki.php
@@ -62,7 +62,11 @@ class Shiki
 
     public function languageIsAvailable(string $language): bool
     {
-        return in_array($language, $this->getAvailableLanguages());
+        $shikiResult = $this->callShiki('aliases');
+
+        $aliases = json_decode($shikiResult, true);
+
+        return in_array($language, $aliases);
     }
 
     public function themeIsAvailable(string $theme): bool

--- a/tests/ShikiCustomRenderTest.php
+++ b/tests/ShikiCustomRenderTest.php
@@ -140,6 +140,9 @@ it('can get all available languages', function () {
     $availableLanguages = (new Shiki())->getAvailableLanguages();
 
     expect($availableLanguages)->not()->toBeEmpty();
+    expect($availableLanguages)->toContain('javascript');
+    // should not include aliases
+    expect($availableLanguages)->not()->toContain('js');
 });
 
 it('can determine that a theme is available', function () {
@@ -154,4 +157,7 @@ it('can determine that a language is available', function () {
 
     expect($shiki->languageIsAvailable('php'))->toBeTrue();
     expect($shiki->languageIsAvailable('non-existing-language'))->toBeFalse();
+    expect($shiki->languageIsAvailable('javascript'))->toBeTrue();
+    // should match aliases
+    expect($shiki->languageIsAvailable('js'))->toBeTrue();
 });

--- a/tests/ShikiCustomRenderTest.php
+++ b/tests/ShikiCustomRenderTest.php
@@ -129,3 +129,29 @@ it('throws on invalid language', function () {
 
     Shiki::highlight($code, 'invalid-language');
 })->throws(Exception::class);
+
+it('can get all available themes', function () {
+    $availableThemes = (new Shiki())->getAvailableThemes();
+
+    expect($availableThemes)->not()->toBeEmpty();
+});
+
+it('can get all available languages', function () {
+    $availableLanguages = (new Shiki())->getAvailableLanguages();
+
+    expect($availableLanguages)->not()->toBeEmpty();
+});
+
+it('can determine that a theme is available', function () {
+    $shiki = (new Shiki());
+
+    expect($shiki->themeIsAvailable('nord'))->toBeTrue();
+    expect($shiki->themeIsAvailable('non-existing-theme'))->toBeFalse();
+});
+
+it('can determine that a language is available', function () {
+    $shiki = (new Shiki());
+
+    expect($shiki->languageIsAvailable('php'))->toBeTrue();
+    expect($shiki->languageIsAvailable('non-existing-language'))->toBeFalse();
+});

--- a/tests/ShikiTest.php
+++ b/tests/ShikiTest.php
@@ -137,6 +137,9 @@ it('can get all available languages', function () {
     $availableLanguages = (new Shiki())->getAvailableLanguages();
 
     expect($availableLanguages)->not()->toBeEmpty();
+    expect($availableLanguages)->toContain('javascript');
+    // should not include aliases
+    expect($availableLanguages)->not()->toContain('js');
 });
 
 it('can determine that a theme is available', function () {
@@ -151,4 +154,7 @@ it('can determine that a language is available', function () {
 
     expect($shiki->languageIsAvailable('php'))->toBeTrue();
     expect($shiki->languageIsAvailable('non-existing-language'))->toBeFalse();
+    expect($shiki->languageIsAvailable('javascript'))->toBeTrue();
+    // should match aliases
+    expect($shiki->languageIsAvailable('js'))->toBeTrue();
 });

--- a/tests/ShikiTest.php
+++ b/tests/ShikiTest.php
@@ -126,3 +126,29 @@ it('throws on invalid language', function () {
 
     Shiki::highlight($code, 'invalid-language');
 })->throws(Exception::class);
+
+it('can get all available themes', function () {
+    $availableThemes = (new Shiki())->getAvailableThemes();
+
+    expect($availableThemes)->not()->toBeEmpty();
+});
+
+it('can get all available languages', function () {
+    $availableLanguages = (new Shiki())->getAvailableLanguages();
+
+    expect($availableLanguages)->not()->toBeEmpty();
+});
+
+it('can determine that a theme is available', function () {
+    $shiki = (new Shiki());
+
+    expect($shiki->themeIsAvailable('nord'))->toBeTrue();
+    expect($shiki->themeIsAvailable('non-existing-theme'))->toBeFalse();
+});
+
+it('can determine that a language is available', function () {
+    $shiki = (new Shiki());
+
+    expect($shiki->languageIsAvailable('php'))->toBeTrue();
+    expect($shiki->languageIsAvailable('non-existing-language'))->toBeFalse();
+});

--- a/tests/testfiles/alt-bin/shiki.js
+++ b/tests/testfiles/alt-bin/shiki.js
@@ -58,7 +58,7 @@ async function main(args) {
     }
 
     if (args[0] === 'themes') {
-        process.stdout.write(JSON.stringify(highlighter.getLoadedThemes()));
+        process.stdout.write(JSON.stringify(Object.keys(shiki.bundledThemes)));
         return;
     }
 

--- a/tests/testfiles/alt-bin/shiki.js
+++ b/tests/testfiles/alt-bin/shiki.js
@@ -38,7 +38,22 @@ async function main(args) {
     if (!customLanguages[language]) await highlighter.loadLanguage(language);
 
     if (args[0] === 'languages') {
-        process.stdout.write(JSON.stringify(highlighter.getLoadedLanguages()));
+        process.stdout.write(
+            JSON.stringify([
+                ...Object.keys(shiki.bundledLanguagesBase),
+                ...Object.keys(customLanguages),
+            ])
+        );
+        return;
+    }
+
+    if (args[0] === 'aliases') {
+        process.stdout.write(
+            JSON.stringify([
+                ...Object.keys(shiki.bundledLanguages),
+                ...Object.keys(customLanguages),
+            ])
+        );
         return;
     }
 


### PR DESCRIPTION
This PR re-adds `getAvailableLanguages`, `getAvailableThemes`, `languageIsAvailable` and `themeIsAvailable` and updates their behavior to correctly read all languages/themes, rather than just currently loaded ones.

Even though individual languages and themes are now lazy-loaded by Shiki, these methods allow an application to introspect the possible assets available for lazy-loading.

This functionality is essential for an application to present a dropdown list of highlighting options to a user, and to validate user-selected languages/themes.

I know you just released a new major version without these methods, but it would not be a breaking change to re-add them. I hope you'll consider this, despite the churn. Thanks!

---

As an implementation detail, this PR differentiates internally between base languages (e.g. `javascript`) and aliases (e.g. `javascript` and `js`). `getAvailableLanguages` returns base languages, while `languageIsAvailable` checks against all aliases.

(This PR also fixes a small nit: `symfony/process` was not required as a dependency.)