### PR TITLE
Allow running in vanilla PHP projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "symfony/process": "^7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "symfony/process": "^7.1"
+        "symfony/process": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.0",


### PR DESCRIPTION
The `symfony/process` is a hard requirement for the project but is no included in the dependency list.

https://github.com/spatie/shiki-php/blob/1895983e02ab9b09071b43ec84467ac4bcdf187a/src/Shiki.php#L64-L72

https://github.com/spatie/shiki-php/blob/1895983e02ab9b09071b43ec84467ac4bcdf187a/src/Shiki.php#L82-L84

This means the package is not usable outside of projects that already depend on `symfony/process`. I hit this on a recent project and had to manually install `symfony/process` even though I was not interacting with it directly.

I tested 5.0, 6.0, and 7.0 against the testsuite and static analysis and all the tests passed on my machine and not additional static analysis issues were introduced with either version.