### PR TITLE
Removed PHP ^7.4 from requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "symfony/process": "^5.4|^6.4|^7.1"
     },


### PR DESCRIPTION
This PR drops PHP ^7.4 from the composer requirements. 

I ran into the following issue:

```php 
Default value for parameters with a class type can only be NULL

  at vendor/spatie/shiki-php/src/Shiki.php:60
     56▕
     57▕     /**
     58▕      * @param string|array<string, string> $defaultTheme Can be a single theme or an array with a light and a dark theme.
     59▕      */
  ➜  60▕     public function __construct(mixed $defaultTheme = 'nord')
     61▕     {
     62▕         $this->defaultTheme = $defaultTheme;
     63▕     }
     64▕

      +1 vendor frames
  2   [internal]:0
      Whoops\Run::handleShutdown()

Fatal error: Default value for parameters with a class type can only be NULL in /Users/timoisik/Documents/dev/tiptap/tiptap-php/vendor/spatie/shiki-php/src/Shiki.php on line 60
Script ./vendor/bin/pest handling the test event returned with error code 255
```

Then I saw, that version ^7.4 has been dropped from the tests: https://github.com/spatie/shiki-php/pull/26#issuecomment-2456756462.

The `mixed` keyword and `union` types are both introduced in PHP version 8 or higher, so without dropping the type hints in the constructor, this library is not compatible with PHP version ^7.4 anymore, but I guess it's OK to drop the support here.