### PR TITLE
Fix: Support for multiple custom themes

### DIFF
--- a/bin/shiki.js
+++ b/bin/shiki.js
@@ -47,9 +47,9 @@ async function main(args) {
             await highlighter.loadTheme(theme);
         }
     } else if (themes) {
-        for (const theme of Object.values(themes)) {
+        for (const [key, theme] of Object.entries(themes)) {
             if (fs.existsSync(theme)) {
-                themes[theme] = loadLocalTheme(theme);
+                themes[key] = loadLocalTheme(theme);
             } else {
                 await highlighter.loadTheme(theme);
             }


### PR DESCRIPTION
This PR fixes an issue with handling multiple custom themes

✅ Works

```php
Shiki::highlight(
    code: '<?php echo "Hello World"; ?>',
    language: 'php',
    theme: 'github-light',
);
Shiki::highlight(
    code: '<?php echo "Hello World"; ?>',
    language: 'php',
    theme: __DIR__ . '/path-to-themes/light.json',
);
Shiki::highlight(
    code: '<?php echo "Hello World"; ?>',
    language: 'php',
    theme: ['light' => 'github-light', 'dark' => 'github-dark'],
);
```
❌ Didn't Work Before
```php
Shiki::highlight(
    code: '<?php echo "Hello World"; ?>',
    language: 'php',
    theme: ['light' => __DIR__ . '/path-to-themes/light.json', 'dark' => __DIR__ . '/path-to-themes/dark.json',],
);
```